### PR TITLE
Can accept arbitrary DropFormats

### DIFF
--- a/Source/NDragDrop/DropTarget.cs
+++ b/Source/NDragDrop/DropTarget.cs
@@ -29,7 +29,12 @@ namespace NDragDrop
         public static readonly DependencyProperty OnDropProperty =
             DependencyProperty.RegisterAttached("OnDrop", typeof (ICommand), typeof (DropTarget), new FrameworkPropertyMetadata(null, OnDropChanged));
 
-        public static void SetOnDrop(UIElement element, ICommand command)
+
+        public static readonly DependencyProperty DropDataTypeProperty =
+            DependencyProperty.RegisterAttached("DropDataType", typeof (string), typeof (DropTarget),
+                new FrameworkPropertyMetadata("NDragDropFormat"));
+        
+       public static void SetOnDrop(UIElement element, ICommand command)
         {
             element.SetValue(OnDropProperty, command);
         }
@@ -37,6 +42,16 @@ namespace NDragDrop
         public static ICommand GetOnDrop(UIElement element)
         {
             return (ICommand)element.GetValue(OnDropProperty);
+        }
+
+        public static string GetDropDataType(UIElement element)
+        {
+            return (string) element.GetValue(DropDataTypeProperty);
+        }
+
+        public static void SetDropDataType(UIElement element, string type)
+        {
+            element.SetValue(DropDataTypeProperty, type);
         }
 
         private static void OnDropChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
@@ -55,7 +70,7 @@ namespace NDragDrop
             var command = GetOnDrop(uiElement);
             if (command != null)
             {
-                command.Execute(new DropEventArgs {Context = dragEventArgs.Data.GetData("NDragDropFormat")});
+                command.Execute(new DropEventArgs { Context = dragEventArgs.Data.GetData(GetDropDataType(uiElement)) });
             }
         }
 


### PR DESCRIPTION
Currently NDragDrop only allows a drop format from NDragDrop. This is right in most cases but in some cases you might need to drop something else, such a file from explorer. In those cases, you need to use a different drop format. To facilitate this, I've added a DropDataType dependency property. By default, this value is set to "NDragDropFormat" which is what the code currently uses. If the user wants, they can add a DropDataType, such as FileDrop for files dragged from explorer, to their UI drop target so they can just receive data of that type.

This doesn't interfere with currently uses of the library but makes it allows it to be used in new places.
