### PR TITLE
Parameterized drops & Replace CanDrop with ICommand.CanExecute

### DIFF
--- a/Source/NDragDrop/DragSource.cs
+++ b/Source/NDragDrop/DragSource.cs
@@ -1,14 +1,12 @@
 ﻿// Copyright (c) 2013 Ronald Valkenburg
 // This software is licensed under the MIT License (see LICENSE file for details)
-
 using System.Windows;
 
 namespace NDragDrop
 {
     public class DragSource : DependencyObject
     {
-        public static readonly DependencyProperty ContextProperty =
-            DependencyProperty.RegisterAttached("Context", typeof(object), typeof(DragSource), new FrameworkPropertyMetadata(null, ContextChanged));
+        public static readonly DependencyProperty ContextProperty = DependencyProperty.RegisterAttached("Context", typeof(object), typeof(DragSource), new FrameworkPropertyMetadata(null, ContextChanged));
 
         public static void SetContext(UIElement element, object value)
         {

--- a/Source/NDragDrop/DropTarget.cs
+++ b/Source/NDragDrop/DropTarget.cs
@@ -13,21 +13,7 @@ namespace NDragDrop
 
     public class DropTarget : DependencyObject
     {
-        public static readonly DependencyProperty CanDropProperty =
-            DependencyProperty.RegisterAttached("CanDrop", typeof(bool), typeof(DropTarget), new FrameworkPropertyMetadata(true));
-
-        public static void SetCanDrop(UIElement element, bool value)
-        {
-            element.SetValue(CanDropProperty, value);
-        }
-
-        public static bool GetCanDrop(UIElement element)
-        {
-            return (bool)element.GetValue(CanDropProperty);
-        }
-
-        public static readonly DependencyProperty OnDropProperty =
-            DependencyProperty.RegisterAttached("OnDrop", typeof (ICommand), typeof (DropTarget), new FrameworkPropertyMetadata(null, OnDropChanged));
+        public static readonly DependencyProperty OnDropProperty = DependencyProperty.RegisterAttached("OnDrop", typeof(ICommand), typeof(DropTarget), new FrameworkPropertyMetadata(null, OnDropChanged));
 
         public static void SetOnDrop(UIElement element, ICommand command)
         {
@@ -42,7 +28,9 @@ namespace NDragDrop
         private static void OnDropChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             var uiElement = d as UIElement;
-            if (uiElement == null) return;
+            if (uiElement == null)
+                return;
+
             uiElement.AllowDrop = true;
             uiElement.DragOver += UiElementDragOver;
             uiElement.Drop += UiElementOnDrop;
@@ -54,20 +42,19 @@ namespace NDragDrop
             if (uiElement == null) return;
             var command = GetOnDrop(uiElement);
             if (command != null)
-            {
-                command.Execute(new DropEventArgs {Context = dragEventArgs.Data.GetData("NDragDropFormat")});
-            }
+                command.Execute(new DropEventArgs { Context = dragEventArgs.Data.GetData("NDragDropFormat") });
         }
 
         private static void UiElementDragOver(object sender, DragEventArgs e)
         {
             var uiElement = sender as UIElement;
-            if (uiElement == null) return;
+            if (uiElement == null) 
+                return;
 
-            if (!GetCanDrop(uiElement))
-            {
+            var command = GetOnDrop(uiElement);
+            if (command != null && !command.CanExecute(null))
                 e.Effects = DragDropEffects.None;
-            }
+
             e.Handled = true;
         }
     }

--- a/Source/NDragDrop/DropTarget.cs
+++ b/Source/NDragDrop/DropTarget.cs
@@ -9,6 +9,7 @@ namespace NDragDrop
     public class DropEventArgs : EventArgs
     {
         public object Context { get; set; }
+        public object Paramter { get; set; }
     }
 
     public class DropTarget : DependencyObject
@@ -23,6 +24,19 @@ namespace NDragDrop
         public static ICommand GetOnDrop(UIElement element)
         {
             return (ICommand)element.GetValue(OnDropProperty);
+        }
+
+
+        public static readonly DependencyProperty OnParameterProperty = DependencyProperty.RegisterAttached("Parameter", typeof(object), typeof(DropTarget), new FrameworkPropertyMetadata(null));
+
+        public static void SetParameter(UIElement element, object parameter)
+        {
+            element.SetValue(OnParameterProperty, parameter);
+        }
+
+        public static object GetParameter(UIElement element)
+        {
+            return element.GetValue(OnParameterProperty);
         }
 
         private static void OnDropChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
@@ -42,7 +56,11 @@ namespace NDragDrop
             if (uiElement == null) return;
             var command = GetOnDrop(uiElement);
             if (command != null)
-                command.Execute(new DropEventArgs { Context = dragEventArgs.Data.GetData("NDragDropFormat") });
+                command.Execute(new DropEventArgs
+                {
+                    Context = dragEventArgs.Data.GetData("NDragDropFormat"),
+                    Paramter = GetParameter(uiElement)
+                });
         }
 
         private static void UiElementDragOver(object sender, DragEventArgs e)

--- a/Source/NDragDrop/NDragDrop.csproj
+++ b/Source/NDragDrop/NDragDrop.csproj
@@ -46,7 +46,6 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="DelegateCommand.cs" />
     <Compile Include="Draggable.cs" />
     <Compile Include="DraggableVisualFeedback.xaml.cs">
       <DependentUpon>DraggableVisualFeedback.xaml</DependentUpon>

--- a/Source/TestApplication/DelegateCommand.cs
+++ b/Source/TestApplication/DelegateCommand.cs
@@ -1,29 +1,35 @@
 ﻿// Copyright (c) 2013 Ronald Valkenburg
 // This software is licensed under the MIT License (see LICENSE file for details)
+
 using System;
+using System.Collections.Generic;
 using System.Windows.Input;
 
-namespace NDragDrop
+namespace NDragDrop.TestApplication
 {
     public class DelegateCommand<T> : ICommand
     {
         private readonly Action<T> _execute;
-
-        public event EventHandler CanExecuteChanged
-        {
-            add { }
-            remove { }
-        }
+        private readonly Predicate<object> _canExecute;
+        private List<WeakReference> canExecuteChangedHandlers;
+        public event EventHandler CanExecuteChanged;
 
         public DelegateCommand(Action<T> execute)
+            : this(execute, null)
+        {
+        }
+
+        public DelegateCommand(Action<T> execute, Predicate<object> canExecute)
         {
             _execute = execute;
+            _canExecute = canExecute;
         }
 
         public bool CanExecute(object parameter)
         {
-            return true;
+            return _canExecute == null || _canExecute(parameter);
         }
+
 
         public void Execute(object parameter)
         {

--- a/Source/TestApplication/MainWindow.xaml
+++ b/Source/TestApplication/MainWindow.xaml
@@ -49,9 +49,7 @@
                 Grid.Column="1"
                 BorderBrush="Black"
                 BorderThickness="1">
-            <ListView ItemsSource="{Binding Apples}"
-                      nDragDrop:DropTarget.CanDrop="{Binding CanDropApples}"
-                      nDragDrop:DropTarget.OnDrop="{Binding DropApple}">
+            <ListView ItemsSource="{Binding Apples}" nDragDrop:DropTarget.OnDrop="{Binding DropApple}">
                 <ListView.ItemTemplate>
                     <DataTemplate DataType="testApplication:Apple">
                         <Border Width="60"

--- a/Source/TestApplication/MainWindow.xaml
+++ b/Source/TestApplication/MainWindow.xaml
@@ -49,10 +49,10 @@
                 Grid.Column="1"
                 BorderBrush="Black"
                 BorderThickness="1">
-            <ListView ItemsSource="{Binding Apples}" nDragDrop:DropTarget.OnDrop="{Binding DropApple}">
+            <ListView ItemsSource="{Binding Apples}" nDragDrop:DropTarget.OnDrop="{Binding DropApple}" nDragDrop:DropTarget.Parameter="DropWithParam" >
                 <ListView.ItemTemplate>
                     <DataTemplate DataType="testApplication:Apple">
-                        <Border Width="60"
+                        <Border MinWidth="60"
                                 Height="60"
                                 Margin="1"
                                 BorderBrush="Green"

--- a/Source/TestApplication/MainWindowViewModel.cs
+++ b/Source/TestApplication/MainWindowViewModel.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.ObjectModel;
+﻿using System;
+using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Windows.Input;
@@ -30,7 +31,12 @@ namespace NDragDrop.TestApplication
                 {
                     var fruit = args.Context as Fruit;
                     if (fruit == null || Fruits.Contains(fruit)) return;
-                    if (fruit is Apple) Apples.Remove((Apple)fruit);
+                    if (fruit is Apple)
+                    {
+                        var apple = (Apple) fruit;
+                        Apples.Remove(apple);
+                        apple.Name = "Apple";
+                    }
                     if (fruit is Banana) Bananas.Remove((Banana) fruit);
                     Fruits.Add(fruit);
                 });
@@ -46,6 +52,7 @@ namespace NDragDrop.TestApplication
                         var apple = args.Context as Apple;
                         if (apple == null || Apples.Contains(apple)) return;
                         Fruits.Remove(apple);
+                        apple.Name = String.Format("{0}- {1}", "Apple", args.Paramter);
                         Apples.Add(apple);
                     }, x => CanDropApples);
             }

--- a/Source/TestApplication/MainWindowViewModel.cs
+++ b/Source/TestApplication/MainWindowViewModel.cs
@@ -47,7 +47,7 @@ namespace NDragDrop.TestApplication
                         if (apple == null || Apples.Contains(apple)) return;
                         Fruits.Remove(apple);
                         Apples.Add(apple);
-                    });
+                    }, x => CanDropApples);
             }
         }
 

--- a/Source/TestApplication/TestApplication.csproj
+++ b/Source/TestApplication/TestApplication.csproj
@@ -65,6 +65,7 @@
       <DependentUpon>App.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="DelegateCommand.cs" />
     <Compile Include="FruitView.xaml.cs">
       <DependentUpon>FruitView.xaml</DependentUpon>
     </Compile>


### PR DESCRIPTION
- Parameterized drops; this way you can handle commands on different controls than where the actually drop has taken place.
- Changed the CanDrop; To be more conform the ICommand usage you can now use the CanExecute functionality of ICommand. No need for extra attached properties. 
