### PR TITLE
Fixed CanExecute/CanDrop & Fixed Handled state

### DIFF
--- a/Source/NDragDrop/DropTarget.cs
+++ b/Source/NDragDrop/DropTarget.cs
@@ -63,20 +63,21 @@ namespace NDragDrop
             uiElement.Drop += UiElementOnDrop;
         }
 
-        private static void UiElementOnDrop(object sender, DragEventArgs dragEventArgs)
+        private static void UiElementOnDrop(object sender, DragEventArgs e)
         {
             var uiElement = sender as UIElement;
             if (uiElement == null) return;
 
             var command = GetOnDrop(uiElement);
-            if (command != null)
+            if (command == null) return;
+            
+            command.Execute(new DropEventArgs
             {
-                command.Execute(new DropEventArgs
-                {
-                    Context = dragEventArgs.Data.GetData(GetDropDataType(uiElement)),
-                    Parameter = GetParameter(uiElement)
-                });
-            }
+                Context = e.Data.GetData(GetDropDataType(uiElement)),
+                Parameter = GetParameter(uiElement)
+            });
+
+            e.Handled = true;
         }
 
         private static void UiElementDragOver(object sender, DragEventArgs e)

--- a/Source/NDragDrop/DropTarget.cs
+++ b/Source/NDragDrop/DropTarget.cs
@@ -16,7 +16,7 @@ namespace NDragDrop
     {
         public static readonly DependencyProperty OnDropProperty =
             DependencyProperty.RegisterAttached("OnDrop", typeof(ICommand), typeof(DropTarget), new FrameworkPropertyMetadata(null, OnDropChanged));
-        
+
         public static void SetOnDrop(UIElement element, ICommand command)
         {
             element.SetValue(OnDropProperty, command);
@@ -39,7 +39,7 @@ namespace NDragDrop
         {
             element.SetValue(DropDataTypeProperty, type);
         }
-        
+
         public static readonly DependencyProperty OnParameterProperty =
             DependencyProperty.RegisterAttached("Parameter", typeof(object), typeof(DropTarget), new FrameworkPropertyMetadata(null));
 
@@ -70,12 +70,9 @@ namespace NDragDrop
 
             var command = GetOnDrop(uiElement);
             if (command == null) return;
-            
-            command.Execute(new DropEventArgs
-            {
-                Context = e.Data.GetData(GetDropDataType(uiElement)),
-                Parameter = GetParameter(uiElement)
-            });
+
+            var dropEventArgs = CreateDropEventArgs(uiElement, e);
+            command.Execute(dropEventArgs);
 
             e.Handled = true;
         }
@@ -86,12 +83,26 @@ namespace NDragDrop
             if (uiElement == null) return;
 
             var command = GetOnDrop(uiElement);
-            if (command != null && !command.CanExecute(null))
+            if (command != null)
             {
-                e.Effects = DragDropEffects.None;
+                var dropEventArgs = CreateDropEventArgs(uiElement, e);
+
+                if (!command.CanExecute(dropEventArgs))
+                {
+                    e.Effects = DragDropEffects.None;
+                }
             }
 
             e.Handled = true;
+        }
+
+        private static DropEventArgs CreateDropEventArgs(UIElement sender, DragEventArgs e)
+        {
+            return new DropEventArgs
+            {
+                Context = e.Data.GetData(GetDropDataType(sender)),
+                Parameter = GetParameter(sender)
+            };
         }
     }
 }


### PR DESCRIPTION
- Handled state fix: When dropping an item on a target while that target has a parent which also accepts drops it bubbles through. This should have been marked as a handled drop.
- CanExecute fix: now allows the implementation of the CanExecute evaluate the "to-drop" data and allowing it do deny/allow the drop.
